### PR TITLE
Fixed fsck on overlain root, added oroot=live, enforced that at least 2 zram block devices are created.

### DIFF
--- a/initcpio/hooks/oroot
+++ b/initcpio/hooks/oroot
@@ -2,9 +2,7 @@
 
 run_hook() {
   if [ "${oroot}" ]; then
-     echo $root | grep UUID && (
-       rootdev=$(resolve_device "$root") && root=$rootdev
-       unset rootdev)
+     root=$(resolve_device $(echo $root | grep UUID))
      $mount_handler /lroot
      modprobe zram num_devices=$(nproc)
      if [ "${quiet}" ]; then


### PR DESCRIPTION
Merge my master branch since it fixes a good deal of your problems. The machine-id problem isn't fixed yet (probably won't) since it's an allowed error according to systemd. Also, there's a new mode called oroot=live which allows running root entirely on ram (copies files to ram). Use it only if your ram is large enough to hold your rootfs. That, and some bug fixes (see commit log)
