### PR TITLE
use `rmdir` in place of `rm -r` when cleaning up mount points

### DIFF
--- a/compiler
+++ b/compiler
@@ -161,7 +161,7 @@ fi
 # unmount and remove drive
 cat <<EOF >> oroot
            umount /run/oroot &&
-           rmdir /run/oroot &&
+           rmdir /run/oroot
 EOF
 
 # close the device in overlay_flush

--- a/compiler
+++ b/compiler
@@ -53,11 +53,11 @@ run_hook() {
         modprobe zram num_devices=\$((\$(nproc)+2))
      fi
      echo "#!/bin/bash
-											set -e
-											if [ "$1" = "--debug" ] || [ "$1" = "-d" ]
-											then
-											  set -x
-											fi
+           set -e
+           if [ \"\$1\" = \"--debug\" ] || [ \"\$1\" = \"-d\" ]
+           then
+             set -x
+           fi
            mkdir /run/oroot
 EOF
 

--- a/compiler
+++ b/compiler
@@ -48,10 +48,10 @@ run_hook() {
         modprobe zram num_devices=\$((\$(nproc)+2))
      fi
      echo "#!/bin/bash
-											if [ "$1" = "--debug" ] || [ "$1" = "-d" ]
-											then
-											  set -x
-											fi
+           if [ "$1" = "--debug" ] || [ "$1" = "-d" ]
+           then
+             set -x
+           fi
            mkdir /run/oroot
 EOF
 

--- a/compiler
+++ b/compiler
@@ -123,7 +123,7 @@ genOverlayFlush </proc/cmdline
 
 # use mount options
 cat <<EOF >> oroot
-             -o $(awk '{if ($2 == "/") {print $4}}' /etc/fstab) \"/run/oroot\"
+             mount -o $(awk '{if ($2 == "/") {print $4}}' /etc/fstab) \"/run/oroot\"
 EOF
 
 if [ "$1" = "btrfs" ]; then

--- a/compiler
+++ b/compiler
@@ -48,6 +48,10 @@ run_hook() {
         modprobe zram num_devices=\$((\$(nproc)+2))
      fi
      echo "#!/bin/bash
+											if [ "$1" = "--debug" ] || [ "$1" = "-d" ]
+											then
+											  set -x
+											fi
            mkdir /run/oroot
 EOF
 

--- a/compiler
+++ b/compiler
@@ -1,7 +1,9 @@
 #!/bin/bash
-if [ "$1" = "--help" ]; then
-    echo "./compiler [btrfs]"
-    echo "    btrfs: enable btrfs specific functionality"
+if [ "$1" = "--help" ] || ! ( [ "$#" -le 1 ] && ( [ "$1" = "btrfs" ] || [ -z "$1" ] ) ); then
+    echo "./compiler [btrfs|--help]"
+    echo "    btrfs:  enable btrfs specific functionality"
+    echo "    --help: print this help"
+    exit 1
 fi
 # build the oroot install hook
 cat <<EOF > oroot_install

--- a/compiler
+++ b/compiler
@@ -48,6 +48,7 @@ run_hook() {
         modprobe zram num_devices=\$((\$(nproc)+2))
      fi
      echo "#!/bin/bash
+											set -e
 											if [ "$1" = "--debug" ] || [ "$1" = "-d" ]
 											then
 											  set -x

--- a/compiler
+++ b/compiler
@@ -1,5 +1,8 @@
 #!/bin/bash
-
+if [ "$1" = "--help" ]; then
+    echo "./compiler [btrfs]"
+    echo "    btrfs: enable btrfs specific functionality"
+fi
 # build the oroot install hook
 cat <<EOF > oroot_install
 #!/bin/ash

--- a/compiler
+++ b/compiler
@@ -161,7 +161,7 @@ fi
 # unmount and remove drive
 cat <<EOF >> oroot
            umount /run/oroot &&
-           rm -r /run/oroot &&
+           rmdir /run/oroot &&
 EOF
 
 # close the device in overlay_flush
@@ -173,7 +173,7 @@ closeOverlayFlush() {
         cat <<EOF >> oroot
            if [ \"\$oroot\" = \"live\" ]; then
               umount \"/run/oroot-key\"
-              rm -r \"/run/oroot-key\"
+              rmdir \"/run/oroot-key\"
            fi
 EOF
         ;;

--- a/compiler
+++ b/compiler
@@ -271,7 +271,7 @@ if [ "$1" = "btrfs" ]; then
 EOF
  else
    cat <<EOF >> oroot
-          cp -a /lroot/* /troot/
+          cp -rTa /lroot/* /troot/
 EOF
 fi
 

--- a/initcpio/hooks/oroot
+++ b/initcpio/hooks/oroot
@@ -1,4 +1,5 @@
 #!/bin/ash
+
 run_hook() {
   if [ "${oroot}" ]; then
      root=$(resolve_device "${root}")
@@ -61,7 +62,7 @@ run_hook() {
      fi;
      unset mem_size;
      if [ "${oroot}" = "live" ]; then
-        cp -a /lroot/* /troot/;
+        cp -rTa /lroot/* /troot/;
         umount /lroot;
         umount /troot;
         export oroot_device;

--- a/initcpio/hooks/oroot
+++ b/initcpio/hooks/oroot
@@ -1,6 +1,4 @@
 #!/bin/ash
-set -e
-set -x
 run_hook() {
   if [ "${oroot}" ]; then
      root=$(resolve_device "${root}")

--- a/initcpio/hooks/oroot
+++ b/initcpio/hooks/oroot
@@ -1,5 +1,6 @@
 #!/bin/ash
-
+set -e
+set -x
 run_hook() {
   if [ "${oroot}" ]; then
      root=$(resolve_device "${root}")
@@ -20,7 +21,7 @@ run_hook() {
               mount -o \$(awk '{if (\$2 == \"/\") {print \$4}}' /etc/fstab) \"$root\" /run/oroot || mount \"$root\" /run/oroot;
               rsync -ax --no-whole-file --inplace --delete / /run/oroot --exclude boot --exclude dev --exclude mnt --exclude proc --exclude run --exclude sys --exclude tmp --exclude usr/bin/overlay_flush;
               umount /run/oroot &&
-              rm -r /run/oroot &&
+              rmdir /run/oroot &&
               cryptsetup close \"$root\";
               " > /overlay_flush;
        elif [[ "${cryptdevice}" && "${oroot}" = "live" && ! -f "/hooks/lvm2" ]]; then
@@ -30,7 +31,7 @@ run_hook() {
               mount -o \$(awk '{if (\$2 == \"/\") {print \$4}}' /etc/fstab) \"$root\" /run/oroot || mount \"$root\" /run/oroot;
               rsync -ax --no-whole-file --inplace --delete / /run/oroot --exclude boot --exclude dev --exclude mnt --exclude proc --exclude run --exclude sys --exclude tmp --exclude usr/bin/overlay_flush;
               umount /run/oroot &&
-              rm -r /run/oroot &&
+              rmdir /run/oroot &&
               cryptsetup close \"$root\";
               " > /overlay_flush;
        else
@@ -39,7 +40,7 @@ run_hook() {
               mount -o \$(awk '{if (\$2 == \"/\") {print \$4}}' /etc/fstab) \"$root\" /run/oroot || mount \"$root\" /run/oroot;
               rsync -ax --no-whole-file --inplace --delete / /run/oroot --exclude boot --exclude dev --exclude mnt --exclude proc --exclude run --exclude sys --exclude tmp --exclude usr/bin/overlay_flush;
               umount /run/oroot &&
-              rm -r /run/oroot &&
+              rmdir /run/oroot &&
               " > /overlay_flush;
      fi;
      chmod ug+x /overlay_flush

--- a/initcpio/hooks/oroot
+++ b/initcpio/hooks/oroot
@@ -39,7 +39,7 @@ run_hook() {
               mount -o \$(awk '{if (\$2 == \"/\") {print \$4}}' /etc/fstab) \"$root\" /run/oroot || mount \"$root\" /run/oroot;
               rsync -ax --no-whole-file --inplace --delete / /run/oroot --exclude boot --exclude dev --exclude mnt --exclude proc --exclude run --exclude sys --exclude tmp --exclude usr/bin/overlay_flush;
               umount /run/oroot &&
-              rmdir /run/oroot &&
+              rmdir /run/oroot
               " > /overlay_flush;
      fi;
      chmod ug+x /overlay_flush

--- a/initcpio/install/oroot
+++ b/initcpio/install/oroot
@@ -1,4 +1,14 @@
 #!/bin/ash
+#vim: set tabstop=8 softtabstop=0 expandtab shiftwidth=4 smarttab
+
+#reads a config file line by line
+#config format is 'key=value' repeated on any number of lines
+IFS='='
+while read -r k v
+do
+  export "oroot_settings_${k}='${v}'"
+done </etc/oroot.conf
+IFS=
 
 build() {
   add_dir /lroot
@@ -9,6 +19,11 @@ build() {
   add_binary free
   add_binary mkfs.ext2
   add_binary nproc
+  if [[ "$oroot_settings_btrfs" != 'false' ]]
+  then
+    add_binary mkfs.btrfs
+    add_binary btrfs
+  fi
   add_runscript
 }
 


### PR DESCRIPTION
fixes issue #21 